### PR TITLE
Revert "add function to place framebuffer in graphics mode"

### DIFF
--- a/common.c
+++ b/common.c
@@ -31,19 +31,13 @@
 #include <sys/mman.h>
 
 #include <linux/fb.h>
-#include <linux/kd.h>
 
 #include "common.h"
 
 void fb_open(int fb_num, struct fb_info *fb_info)
 {
 	char str[64];
-	int fd,tty;
-
-	tty = open("/dev/tty1", O_RDWR);
-
-	if(ioctl(tty, KDSETMODE, KD_GRAPHICS) == -1)
-		printf("Failed to set graphics mode on tty1\n");
+	int fd;
 
 	sprintf(str, "/dev/fb%d", fb_num);
 	fd = open(str, O_RDWR);


### PR DESCRIPTION
First of all, it's completely unclear why /dev/tty1 is being hardcoded.
Second, the function may switch the console to a wrong mode without restoring.
Last, but not least, this breaks display in hotplug mode in my case.

I have an SPI panel connected and I load an overlay to enable it. If I ran
fb-test and do unload-load cycle, display becomes unusable till the reboot.

Revert hack commit 77bdfc6ccbebb39caed4ac167a983ad3ad1e1ccb for good.

This fixes issue #4.

Link: https://github.com/HED-Inc/fb-test-app/commit/ef9c21a2e55160ad52c40f7c2a07fcab95e484e1
Signed-off-by: Andy Shevchenko <andriy.shevchenko@linux.intel.com>